### PR TITLE
Пример для Unit test case

### DIFF
--- a/tests/unit.suite.yml
+++ b/tests/unit.suite.yml
@@ -7,4 +7,15 @@ modules:
     enabled:
         - Asserts
         - \Helper\Unit
-    step_decorators: ~        
+    step_decorators: ~
+
+extensions:
+    enabled:
+        - Yandex\Allure\Codeception\AllureCodeception
+    config:
+        Yandex\Allure\Codeception\AllureCodeception:
+            deletePreviousResults: true
+            outputDirectory: allure-results
+            ignoredAnnotations:
+                - env
+                - dataprovider

--- a/tests/unit/PhpUnitTest.php
+++ b/tests/unit/PhpUnitTest.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace unit;
+
+
+use PHPUnit\Framework\TestCase;
+
+class PhpUnitTest extends TestCase
+{
+    public function testSum()
+    {
+        $this->assertSame(1, 0 + 1);
+    }
+}


### PR DESCRIPTION
Результат выполнения теста PhpUnitTest выглядит следующим образом. Имя `testSum` мало информативно. Есть ли возможность Именем сделать например пойлный нейпсейс и имя теста. Вот так например: `unit\PhpUnitTest:testSum`
```
<?xml version="1.0" encoding="UTF-8"?>
<alr:test-suite xmlns:alr="urn:model.allure.qatools.yandex.ru" start="1590390136954" stop="1590390136961" version="1.4.0">
  <name>unit</name>
  <test-cases>
    <test-case start="1590390136956" stop="1590390136960" status="passed">
      <name>testSum</name>
    </test-case>
  </test-cases>
</alr:test-suite>

```